### PR TITLE
Oppgraderer Spring Boot, pakker, og actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,6 @@ registries:
     url: https://maven.pkg.github.com/navikt/k9-format
     username: x-access-token
     password: ${{secrets.DEPENDABOT_TOKEN}}
-  token-support:
-    type: maven-repository
-    url: https://maven.pkg.github.com/navikt/token-support
-    username: x-access-token
-    password: ${{secrets.DEPENDABOT_TOKEN}}
 
 updates:
   - package-ecosystem: github-actions
@@ -25,4 +20,3 @@ updates:
       interval: daily
     registries:
       - k9-format
-      - token-support

--- a/.github/workflows/apply-alerts.yml
+++ b/.github/workflows/apply-alerts.yml
@@ -17,7 +17,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/dev-') || startsWith(github.ref, 'refs/heads/master') # Deploy if branch is either master or dev-*
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
@@ -30,7 +30,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/master')  # If the branch is master
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,19 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.4.0
-      - name: Cache
-        uses: actions/cache@v2.1.7
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+        uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: 11
           distribution: 'zulu'
+          cache: 'gradle'
       - name: Test Code
         run: ./gradlew check
 
@@ -46,19 +40,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.4.0
-      - name: Cache
-        uses: actions/cache@v2.1.7
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+        uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: 11
           distribution: 'zulu'
+          cache: 'gradle'
       - name: Build JAR
         run: ./gradlew clean build -x test # Creates a combined JAR of project and runTime dependencies.
       - name: Build and publish Docker image
@@ -73,7 +61,7 @@ jobs:
     needs: build-code-and-push-docker # Depends on build-code-and-push-docker job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
@@ -87,7 +75,7 @@ jobs:
     needs: build-code-and-push-docker # Depends on build-code-and-push-docker job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}

--- a/.github/workflows/deploy-kafka-topics.yml
+++ b/.github/workflows/deploy-kafka-topics.yml
@@ -11,7 +11,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/dev-') || startsWith(github.ref, 'refs/heads/master') # Deploy if branch is either master or dev-*
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
@@ -24,7 +24,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/master')  # If the branch is master
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,7 +10,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
 
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/gradle@master

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ gjøre kall på endepunktene, må man ha et gyldig token.
 1. Åpne oicd-provider-gui i nettleseren enten ved å bruke docker dashbord, eller ved å gå til http://localhost:5000.
 2. Trykk "Token for nivå 4" for å logge inn med ønsket bruker, ved å oppgi fødselsnummer. Tokenet blir da satt som en
    cookie (selvbetjening-idtoken) i nettleseren.
-3. Deretter kan du åpne http://localhost:8080/swagger-ui/index.html for å teste ut endepunktene.
+3. Deretter kan du åpne http://localhost:8080/swagger-ui.html for å teste ut endepunktene.
 
 Om man ønsker å bruke postman må man selv, lage en cookie og sette tokenet manuelt. Eksempel:
 selvbetjening-idtoken=eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp.eyJzdWIiOiIwMTAxMDExMjM0NSIsImFjc.FBmVFuHI9d8akrVdAxi1dRg03qKV4EGk;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "2.5.7"
+    id("org.springframework.boot") version "2.6.5"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
     kotlin("jvm") version "1.6.10"
     kotlin("plugin.spring") version "1.6.10"
@@ -18,12 +18,12 @@ configurations {
     }
 }
 
-val springfoxVersion by extra("3.0.0")
+val springdocVersion by extra("1.6.6")
 val confluentVersion by extra("5.5.0")
 val logstashLogbackEncoderVersion by extra("6.6")
-val tokenSupportVersion by extra("1.3.8")
+val tokenSupportVersion by extra("1.3.19")
 val k9FormatVersion by extra("5.5.20")
-val springCloudVersion by extra("2020.0.3")
+val springCloudVersion by extra("2021.0.1")
 val retryVersion by extra("1.3.0")
 val zalandoVersion by extra("0.26.2")
 val hibernateTypes52Version by extra("2.11.1")
@@ -37,7 +37,6 @@ val orgJsonVersion by extra("20210307")
 
 ext["okhttp3.version"] = okHttp3Version
 ext["testcontainersVersion"] = "1.16.3"
-ext["log4j2.version"] = "2.15.0" // TODO: 13/12/2021 kan fjernes når spring boot oppgraderes til  v2.5.8 eller v2.6.2
 
 repositories {
     mavenCentral()
@@ -95,8 +94,9 @@ dependencies {
     testImplementation("org.springframework.cloud:spring-cloud-starter-contract-stub-runner")
     testImplementation("org.springframework.cloud:spring-cloud-starter")
 
-    // SpringFox
-    implementation("io.springfox:springfox-boot-starter:$springfoxVersion")
+    // Swagger (openapi 3)
+    implementation("org.springdoc:springdoc-openapi-kotlin:$springdocVersion")
+    implementation("org.springdoc:springdoc-openapi-ui:$springdocVersion")
 
     // Metrics
     implementation("io.micrometer:micrometer-registry-prometheus")

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -34,7 +34,8 @@
     "NO_NAV_GATEWAYS_K9_SELVBETJENING_OPPSLAG": "https://k9-selvbetjening-oppslag.dev-fss-pub.nais.io",
     "NO_NAV_GATEWAYS_SAF_BASE_URL": "https://saf.dev-fss-pub.nais.io",
     "TOKENDINGS_BASE_URL": "https://tokendings.dev-gcp.nais.io",
-    "K9_SELVBETJENING_OPPSLAG_TOKEN_X_AUDIENCE": "dev-fss:dusseldorf:k9-selvbetjening-oppslag"
+    "K9_SELVBETJENING_OPPSLAG_TOKEN_X_AUDIENCE": "dev-fss:dusseldorf:k9-selvbetjening-oppslag",
+    "SWAGGER_ENABLED": "true"
   },
   "slack-channel": "sif-alerts-dev",
   "slack-notify-type": "<!here> | k9-sak-innsyn-api | "

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SecurityConfiguration.kt
@@ -3,6 +3,6 @@ package no.nav.sifinnsynapi.config
 import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
 import org.springframework.context.annotation.Configuration
 
-@EnableJwtTokenValidation(ignore = ["org.springframework", "springfox.documentation"])
+@EnableJwtTokenValidation(ignore = ["org.springframework", "org.springdoc"])
 @Configuration
 internal class SecurityConfiguration

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -1,14 +1,14 @@
 package no.nav.sifinnsynapi.config
 
-import io.swagger.models.Scheme
+import io.swagger.v3.oas.models.ExternalDocumentation
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.servers.Server
 import org.springframework.context.EnvironmentAware
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.core.env.Environment
-import springfox.documentation.builders.RequestHandlerSelectors
-import springfox.documentation.spi.DocumentationType
-import springfox.documentation.spring.web.plugins.Docket
 
 @Configuration
 @Profile("local", "dev-gcp")
@@ -16,12 +16,22 @@ class SwaggerConfiguration : EnvironmentAware {
     private var env: Environment? = null
 
     @Bean
-    fun api(): Docket {
-        return Docket(DocumentationType.SWAGGER_2)
-                .protocols(setOf(Scheme.HTTP.toValue(), Scheme.HTTPS.toValue()))
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("no.nav.sifinnsynapi"))
-                .build()
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .addServersItem(
+                Server().url("https://k9-sak-innsyn-api.dev.nav.no/").description("Swagger Server")
+            )
+            .info(
+                Info()
+                    .title("K9 Sak Innsyn Api")
+                    .description("API spesifikasjon for k9-sak-innsyn-api")
+                    .version("v1.0.0")
+            )
+            .externalDocs(
+                ExternalDocumentation()
+                    .description("K9 Sak Innsyn Api GitHub repository")
+                    .url("https://github.com/navikt/k9-sak-innsyn-api")
+            )
     }
 
     override fun setEnvironment(env: Environment) {

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/WebMvcConfig.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/WebMvcConfig.kt
@@ -20,22 +20,6 @@ class WebMvcConfig() : WebMvcConfigurer {
         val log: Logger = LoggerFactory.getLogger(WebMvcConfigurer::class.java)
     }
 
-    /**
-     * Add handlers to serve static resources such as images, js, and, css
-     * files from specific locations under web application root, the classpath,
-     * and others.
-     */
-    override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
-
-        registry.addResourceHandler("swagger-ui.html")
-            .addResourceLocations("classpath:/META-INF/resources/");
-
-        registry.addResourceHandler("/webjars/**")
-            .addResourceLocations("classpath:/META-INF/resources/webjars/");
-
-        super.addResourceHandlers(registry)
-    }
-
     @Bean
     fun problemModules(): ProblemModule {
         return ProblemModule()

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/CommonKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/kafka/CommonKafkaConfig.kt
@@ -17,6 +17,7 @@ import org.apache.kafka.common.config.SslConfigs
 import org.slf4j.Logger
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.*
+import org.springframework.kafka.listener.ConsumerRecordRecoverer
 import org.springframework.kafka.listener.ContainerProperties
 import org.springframework.kafka.listener.DefaultAfterRollbackProcessor
 import org.springframework.kafka.support.KafkaHeaders
@@ -139,7 +140,7 @@ class CommonKafkaConfig {
             factory.containerProperties.transactionManager = transactionManager
 
             // https://docs.spring.io/spring-kafka/docs/2.5.2.RELEASE/reference/html/#exactly-once
-            factory.containerProperties.eosMode = ContainerProperties.EOSMode.BETA
+            factory.containerProperties.eosMode = ContainerProperties.EOSMode.V2
 
             // https://docs.spring.io/spring-kafka/docs/2.5.2.RELEASE/reference/html/#committing-offsets
             factory.containerProperties.ackMode = ContainerProperties.AckMode.RECORD;
@@ -148,7 +149,7 @@ class CommonKafkaConfig {
             factory.containerProperties.isDeliveryAttemptHeader = true
 
             // https://docs.spring.io/spring-kafka/reference/html/#listener-container
-            factory.containerProperties.authorizationExceptionRetryInterval = Duration.ofSeconds(10L)
+            factory.containerProperties.setAuthExceptionRetryInterval(Duration.ofSeconds(10L))
 
             //https://docs.spring.io/spring-kafka/docs/2.5.2.RELEASE/reference/html/#after-rollback
 
@@ -176,7 +177,7 @@ class CommonKafkaConfig {
             }
 
 
-        fun defaultRecoverer(logger: Logger) = BiConsumer { cr: ConsumerRecord<*, *>, ex: Exception ->
+        fun defaultRecoverer(logger: Logger) = ConsumerRecordRecoverer { cr: ConsumerRecord<*, *>, ex: Exception ->
             logger.error("Retry attempts exhausted for ${cr.topic()}-${cr.partition()}@${cr.offset()}", ex)
         }
     }

--- a/src/main/resources/application-prod-gcp.yml
+++ b/src/main/resources/application-prod-gcp.yml
@@ -17,7 +17,7 @@ spring:
   jpa:
     show-sql: false
     hibernate:
-      ddl-auto: create-drop # TODO: Sett til none etter prodsetting.
+      ddl-auto: none
 
 kafka:
   aiven:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,3 +69,11 @@ kafka:
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
       transaction-id-prefix: .tx-
       retries: 3
+
+springdoc:
+  api-docs:
+    enabled: ${SWAGGER_ENABLED:false}
+  swagger-ui:
+    enabled: ${SWAGGER_ENABLED:false}
+    disable-swagger-default-url: true
+    path: swagger-ui.html


### PR DESCRIPTION
Erstatter Springfox med Springdoc da den ikke fungerte som den skal etter opppdatering av Spring. Springdoc er et mer vedlikeholdt prosjekt og mer kompatibelt med spring og openapi.

- Setter jpa.hibernate.ddl-auto til none for prod profil.
- Fjerner resourceHandler config for swagger, da den ikke lenger er nødvendig.
- Oppdaterer tokenSupportVersion
- Oppdaterer springCloudVersion
- Erstatter utgått kafka config.
- Erstatter gh-action cache med cache fra setup-java.
- Fjerner dependabot registry config for token-support. Dette burde dukke opp av seg selv.
- closes #19
- closes #18
- closes #15