### PR TITLE
Ignorer feil mot k9 sak

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/k9sak/K9SakService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/k9sak/K9SakService.kt
@@ -1,6 +1,7 @@
 package no.nav.sifinnsynapi.k9sak
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import kotlinx.coroutines.NonCancellable.message
 import no.nav.k9.sak.typer.Saksnummer
 import no.nav.sifinnsynapi.common.AktørId
 import org.slf4j.Logger
@@ -62,8 +63,11 @@ class K9SakService(
         inputDto: HentSisteGyldigeVedtakForAktorIdDto
     ): HentSisteGyldigeVedtakForAktorIdResponse? {
         logger.error("Fikk en HttpClientErrorException når man kalte hentSisteGyldigeVedtakForAktorId tjeneste i k9-sak. Error response = '${exception.responseBodyAsString}'")
-        val message = exception.responseBodyAsString.ifEmpty { exception.message.orEmpty() }
-        throw K9SakException(message, HttpStatus.valueOf(exception.statusCode.value()))
+        return HentSisteGyldigeVedtakForAktorIdResponse(
+            harInnvilgedeBehandlinger = false,
+            saksnummer = null,
+            vedtaksdato = null,
+        )
     }
 
     @Recover
@@ -72,8 +76,11 @@ class K9SakService(
         inputDto: HentSisteGyldigeVedtakForAktorIdDto
     ): HentSisteGyldigeVedtakForAktorIdResponse? {
         logger.error("Fikk en HttpServerErrorException når man kalte hentSisteGyldigeVedtakForAktorId tjeneste i k9-sak.")
-        val message = exception.responseBodyAsString.ifEmpty { exception.message.orEmpty() }
-        throw K9SakException(message, HttpStatus.valueOf(exception.statusCode.value()))
+        return HentSisteGyldigeVedtakForAktorIdResponse(
+            harInnvilgedeBehandlinger = false,
+            saksnummer = null,
+            vedtaksdato = null,
+        )
     }
 
     @Recover
@@ -82,8 +89,11 @@ class K9SakService(
         inputDto: HentSisteGyldigeVedtakForAktorIdDto
     ): HentSisteGyldigeVedtakForAktorIdResponse? {
         logger.error("Fikk en ResourceAccessException når man kalte hentSisteGyldigeVedtakForAktorId tjeneste i k9-sak.")
-        val message = exception.message.orEmpty()
-        throw K9SakException(message, HttpStatus.INTERNAL_SERVER_ERROR)
+        return HentSisteGyldigeVedtakForAktorIdResponse(
+            harInnvilgedeBehandlinger = false,
+            saksnummer = null,
+            vedtaksdato = null,
+        )
     }
 }
 

--- a/src/main/kotlin/no/nav/sifinnsynapi/k9sak/K9SakService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/k9sak/K9SakService.kt
@@ -1,7 +1,6 @@
 package no.nav.sifinnsynapi.k9sak
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import kotlinx.coroutines.NonCancellable.message
 import no.nav.k9.sak.typer.Saksnummer
 import no.nav.sifinnsynapi.common.AktørId
 import org.slf4j.Logger

--- a/src/test/kotlin/no/nav/sifinnsynapi/k9sak/K9SakServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/k9sak/K9SakServiceTest.kt
@@ -12,6 +12,8 @@ import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import no.nav.sifinnsynapi.common.AktørId
 import no.nav.sifinnsynapi.utils.hentToken
+import org.junit.Assert
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -114,17 +116,21 @@ internal class K9SakServiceTest {
             """.trimIndent()
         )
 
-        assertThrows<K9SakException> {
-            k9SakService.hentSisteGyldigeVedtakForAktorId(
-                HentSisteGyldigeVedtakForAktorIdDto(
-                    pleietrengendeAktør
-                )
+        val resultat = k9SakService.hentSisteGyldigeVedtakForAktorId(
+            HentSisteGyldigeVedtakForAktorIdDto(
+                pleietrengendeAktør
             )
-        }
+        )
 
         WireMock.verify(
             3,
             postRequestedFor(urlEqualTo(omsorgsdagerKroniskSyktBarnHarGyldigVedtakUrl))
+        )
+
+        Assertions.assertEquals(
+            resultat, HentSisteGyldigeVedtakForAktorIdResponse(
+                harInnvilgedeBehandlinger = false, saksnummer = null, vedtaksdato = null
+            )
         )
     }
 
@@ -144,17 +150,21 @@ internal class K9SakServiceTest {
             """.trimIndent()
         )
 
-        assertThrows<K9SakException> {
-            k9SakService.hentSisteGyldigeVedtakForAktorId(
-                HentSisteGyldigeVedtakForAktorIdDto(
-                    pleietrengendeAktør
-                )
+        val resultat = k9SakService.hentSisteGyldigeVedtakForAktorId(
+            HentSisteGyldigeVedtakForAktorIdDto(
+                pleietrengendeAktør
             )
-        }
+        )
 
         WireMock.verify(
             1,
             postRequestedFor(urlEqualTo(omsorgsdagerKroniskSyktBarnHarGyldigVedtakUrl))
+        )
+
+        Assertions.assertEquals(
+            resultat, HentSisteGyldigeVedtakForAktorIdResponse(
+                harInnvilgedeBehandlinger = false, saksnummer = null, vedtaksdato = null
+            )
         )
     }
 


### PR DESCRIPTION
Om man prøver å slå opp siste vedtak i K9, og K9 av en eller annen grunn skulle feile, så returnerer vi nå heller en standard "ingen tidligere vedtak" respons, så bruker får lov til å søke. Bedre med en søknad for mye, enn å nekte noen å søke basert på en teknisk feil som ikke egentlig stopper innsendingen.