### PR TITLE
Nytt bekreftelsesbrev til arbeidsgiver tilpasset inntektsmelding gjennom nav.no

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/pdf/ArbeidsgiverMeldingNavNoPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/pdf/ArbeidsgiverMeldingNavNoPDFGenerator.kt
@@ -5,15 +5,12 @@ import org.springframework.stereotype.Service
 import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
 
-@Deprecated(
-    "Etter at ny inntektsmelding gjennom nav.no er aktivert, ønsker vi ikke å bruke denne lenger",
-    ReplaceWith("ArbeidsgiverMeldingNavNoPDFGenerator")
-)
 @Service
-class ArbeidsgiverMeldingPDFGenerator : PDFGenerator<PleiepengerArbeidsgiverMelding>() {
+class ArbeidsgiverMeldingNavNoPDFGenerator : PDFGenerator<PleiepengerArbeidsgiverMelding>() {
 
     override val templateNavn: String
-        get() = "informasjonsbrev-til-arbeidsgiver"
+        get() = "informasjonsbrev-til-arbeidsgiver-nav-no"
+
 
     override fun PleiepengerArbeidsgiverMelding.tilMap(): Map<String, Any?> = mapOf(
         "arbeidsgiver_navn" to arbeidsgivernavn?.storForbokstav(),

--- a/src/main/kotlin/no/nav/sifinnsynapi/pdf/PleiepengerArbeidsgiverMelding.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/pdf/PleiepengerArbeidsgiverMelding.kt
@@ -1,0 +1,7 @@
+package no.nav.sifinnsynapi.pdf
+
+data class PleiepengerArbeidsgiverMelding(
+    val arbeidstakernavn: String,
+    val arbeidsgivernavn: String? = null,
+    val søknadsperiode: SøknadsPeriode
+)

--- a/src/main/kotlin/no/nav/sifinnsynapi/pdf/SøknadsPeriode.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/pdf/SøknadsPeriode.kt
@@ -1,0 +1,8 @@
+package no.nav.sifinnsynapi.pdf
+
+import java.time.LocalDate
+
+data class SøknadsPeriode(
+    val fraOgMed: LocalDate,
+    val tilOgMed: LocalDate
+)

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -34,3 +34,7 @@ kafka:
         key-store-location: file:${KAFKA_KEYSTORE_PATH}
         key-store-password: ${KAFKA_CREDSTORE_PASSWORD}
         key-store-type: PKCS12
+
+no.nav:
+  inntektsmelding:
+    ny-im-aktivert: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,9 @@ no.nav:
     saf-selvbetjening-base-url: # Settes i nais/<cluster>.json
     sif-innsyn-api-base-url: # Settes i nais/<cluster>.json
 
+  inntektsmelding:
+    ny-im-aktivert: false
+
   security:
     k9-drift-gruppe: ${K9_DRIFT_GRUPPE_ID}
     jwt:

--- a/src/main/resources/handlebars/informasjonsbrev-til-arbeidsgiver-nav-no.hbs
+++ b/src/main/resources/handlebars/informasjonsbrev-til-arbeidsgiver-nav-no.hbs
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="NO">
+
+<head>
+    <meta charset="UTF-8"/>
+    <title>Bekreftelse til Arbeidsgiver</title>
+    <meta name="subject" content="Informasjonsbrev til Arbeidsgiver"/>
+    <meta name="author" content="nav.no"/>
+    <meta name="description" content="Bekreftelse til Arbeidsgiver {{soknad_mottatt_dag}} {{ soknad_mottatt }}"/>
+    <bookmarks>
+        <bookmark name="Informasjon" href="#informasjon"/>
+        <bookmark name="Instruksjon" href="#instruksjon"/>
+    </bookmarks>
+    {{#block 'style-common' }}
+    {{/block}}
+</head>
+
+<body>
+<div class="innholdscontainer">
+    <span id="header"></span>
+
+    <section id="informasjon">
+        <h1>Til {{arbeidsgiver_navn}}</h1>
+        <p><strong>{{arbeidstaker_navn}}</strong> har søkt om pleiepenger for perioden</p>
+        <ul>
+            <li>
+                <strong>{{periode.fom}} - {{periode.tom}}</strong>
+            </li>
+        </ul>
+
+        <p>
+            Hvis vi trenger inntektsmelding for å behandle søknaden, vil du få varsel om dette via Altinn og på
+            Min side – arbeidsgiver på nav.no. Du kan da logge inn på nav.no for å sende inn en forhåndsutfylt
+            inntektsmelding.
+        </p>
+
+        <p>
+            Det er også mulig å sende inntektsmelding fra Altinn og lønns- og personalsystem, men du må da være
+            observant på at vi får riktig informasjon om første fraværsdag, organisasjonsnummer og eventuelt
+            arbeidsforholds-id.
+        </p>
+
+        <p>
+            Som hovedregel trenger vi inntektsmelding hvis dette er første søknad, eller hvis det har vært et
+            opphold på minst 4 uker. Hvis det har vært et kortere opphold mellom pleiepengeperiodene, der den
+            ansatte har hatt en varig lønnsendring, trenger vi også ny inntektsmelding.
+        </p>
+    </section>
+
+    <section id="spørsmål">
+        <h2>Har dere spørsmål?</h2>
+        <p>Dere finner mer informasjon på <a href="https://nav.no/arbeidsgiver">nav.no/arbeidsgiver</a></p>
+
+        <p>På <a href="https://nav.no/kontakt">nav.no/kontakt</a> kan dere chatte med oss.</p>
+
+        <p>Dere kan også ringe oss på telefon 55 55 33 36, hverdager 09.00-15.00.</p>
+    </section>
+</div>
+
+<!-- FOOTER -->
+<p id="footer">
+    <span class="tidspunkt">{{ tidspunkt }}</span>
+    <span class="sidetall">side <span id="pagenumber"></span> av <span id="pagecount"></span></span>
+</p>
+</body>
+
+</html>

--- a/src/test/kotlin/no/nav/sifinnsynapi/pdf/ArbeidsgiverMeldingNavNoPDFGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/pdf/ArbeidsgiverMeldingNavNoPDFGeneratorTest.kt
@@ -1,0 +1,25 @@
+package no.nav.sifinnsynapi.pdf
+
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.time.LocalDate
+
+class ArbeidsgiverMeldingNavNoPDFGeneratorTest {
+
+    @Test
+    fun pdf() {
+        val pdf = ArbeidsgiverMeldingNavNoPDFGenerator().genererPDF(
+            melding = PleiepengerArbeidsgiverMelding(
+                arbeidstakernavn = "Ola Nordmann",
+                arbeidsgivernavn = "Sjokkerende Elektriker",
+                søknadsperiode = SøknadsPeriode(
+                    fraOgMed = LocalDate.now().minusWeeks(1),
+                    tilOgMed = LocalDate.now().plusWeeks(1)
+                )
+            )
+        )
+        File(pdfPath("Bekreftelse til arbeidsgiver")).writeBytes(pdf)
+    }
+
+    private fun pdfPath(filnavn: String) = "${System.getProperty("user.dir")}/generated-pdf-$filnavn.pdf"
+}


### PR DESCRIPTION
## Bakgrunn
I forbindelse med ny inntektsmelding gjennom nav.no som først skal tas i bruk for pleiepenger, ønsker vi å informere arbeidsgiver om at de kan sende inn inntektsmelding der. 

Jira oppgave: https://jira.adeo.no/browse/TSFF-1039

## Løsning
* Har tatt utgangspunkt i den eksisterende `ArbeidsgiverMeldingPDFGenerator` og lagd en tilsvarende `ArbeidsgiverMeldingNavNoPDFGenerator` som henter riktig brevmal.
* Lagt til feature toggle som styres fra `SøknadService`.

## Notat
Denne PR-en skal være lik PR-en i sif-innsyn-api: https://github.com/navikt/sif-innsyn-api/pull/538

## Bilder
|  Beskrivelse av brevet | Det genererte brevet |
| ------------- | ------------- |
| ![Screenshot 2025-01-14 at 17 23 20](https://github.com/user-attachments/assets/47d9eb41-ef17-4d74-85b9-ff2be04ee3df)  | ![Screenshot 2025-01-14 at 17 30 11](https://github.com/user-attachments/assets/49b68669-a3e1-4d66-b015-8a707edecbf5) |






