### PR TITLE
Dev omsorgstilbud per soker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ build/
 .settings
 .springBeans
 .sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
 .idea

--- a/src/main/kotlin/no/nav/sifinnsynapi/drift/DriftService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/drift/DriftService.kt
@@ -12,7 +12,6 @@ import no.nav.sifinnsynapi.soknad.SøknadRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.stream.Stream
 
 
 @Service
@@ -43,7 +42,6 @@ class DriftService(
                     søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(søkerAktørId, pleietrengendeAktørId)
                         .map { it: PsbSøknadDAO -> JsonUtils.fromString(it.søknad, Søknad::class.java) }
                         .filter { it: Søknad -> !ekskluderteSøknadIder.contains(it.søknadId.id) }
-                        .toList()
 
                 slåSammenSøknaderFor(søkerAktørId, pleietrengendeAktørId, ekskluderteSøknadIder)?.somDebugDTO(
                     pleietrengendeAktørId,
@@ -59,15 +57,11 @@ class DriftService(
         ekskluderteSøknadIder: List<String>,
     ): Søknad? {
         return søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(søkersAktørId, pleietrengendeAktørId)
-            .use { søknadStream: Stream<PsbSøknadDAO> ->
-                søknadStream
-                    .map { psbSøknadDAO: PsbSøknadDAO ->
-                        JsonUtils.fromString(psbSøknadDAO.søknad, Søknad::class.java)
-                    }
-                    .filter { søknad: Søknad -> !ekskluderteSøknadIder.contains(søknad.søknadId.id) }
-                    .reduce(Søknadsammenslåer::slåSammen)
-                    .orElse(null)
+            .map { psbSøknadDAO: PsbSøknadDAO ->
+                JsonUtils.fromString(psbSøknadDAO.søknad, Søknad::class.java)
             }
+            .filter { søknad: Søknad -> !ekskluderteSøknadIder.contains(søknad.søknadId.id) }
+            .reduceOrNull(Søknadsammenslåer::slåSammen)
     }
 
     private fun Søknad.somDebugDTO(pleietrengendeAktørId: String, alleSøknader: List<Søknad>? = null): DebugDTO {

--- a/src/main/kotlin/no/nav/sifinnsynapi/drift/DriftService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/drift/DriftService.kt
@@ -40,8 +40,8 @@ class DriftService(
         return pleietrengendeAktørIder
             .mapNotNull { pleietrengendeAktørId ->
                 val alleSøknader =
-                    søknadRepository.findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc(pleietrengendeAktørId)
-                        .map { it: PsbSøknadDAO -> it.kunPleietrengendeDataFraAndreSøkere(søkerAktørId) }
+                    søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(søkerAktørId, pleietrengendeAktørId)
+                        .map { it: PsbSøknadDAO -> JsonUtils.fromString(it.søknad, Søknad::class.java) }
                         .filter { it: Søknad -> !ekskluderteSøknadIder.contains(it.søknadId.id) }
                         .toList()
 
@@ -58,11 +58,11 @@ class DriftService(
         pleietrengendeAktørId: String,
         ekskluderteSøknadIder: List<String>,
     ): Søknad? {
-        return søknadRepository.findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc(pleietrengendeAktørId)
+        return søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(søkersAktørId, pleietrengendeAktørId)
             .use { søknadStream: Stream<PsbSøknadDAO> ->
                 søknadStream
                     .map { psbSøknadDAO: PsbSøknadDAO ->
-                        psbSøknadDAO.kunPleietrengendeDataFraAndreSøkere(søkersAktørId)
+                        JsonUtils.fromString(psbSøknadDAO.søknad, Søknad::class.java)
                     }
                     .filter { søknad: Søknad -> !ekskluderteSøknadIder.contains(søknad.søknadId.id) }
                     .reduce(Søknadsammenslåer::slåSammen)
@@ -78,13 +78,6 @@ class DriftService(
         )
     }
 
-    private fun PsbSøknadDAO.kunPleietrengendeDataFraAndreSøkere(søkerAktørId: String): Søknad {
-        val søknad = JsonUtils.fromString(this.søknad, Søknad::class.java)
-        return when (this.søkerAktørId) {
-            søkerAktørId -> søknad
-            else -> Søknadsammenslåer.kunPleietrengendedata(søknad)
-        }
-    }
 
     fun oppdaterAktørId(gyldig: String, utgått: String): Int {
         var antallRader = 0

--- a/src/main/kotlin/no/nav/sifinnsynapi/omsorg/OmsorgService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/omsorg/OmsorgService.kt
@@ -1,15 +1,21 @@
 package no.nav.sifinnsynapi.omsorg
 
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class OmsorgService(
     private val omsorgRepository: OmsorgRepository
 ) {
 
-    fun harOmsorgen(søkerAktørId: String, pleietrengendeAktørId: String): Boolean =
-        hentOmsorg(søkerAktørId, pleietrengendeAktørId)?.harOmsorgen ?: false
+    fun hentOmsorgStatus(søkerAktørId: String, pleietrengendeAktørId: String): OmsorgStatus {
+        val omsorg = hentOmsorg(søkerAktørId, pleietrengendeAktørId)
+
+        return when (omsorg?.harOmsorgen) {
+            true -> OmsorgStatus.HAR_OMSORGEN
+            false -> OmsorgStatus.HAR_IKKE_OMSORGEN
+            null -> OmsorgStatus.HAR_IKKE_EVALUERT_OMSORGEN
+        }
+    }
 
     fun omsorgEksisterer(søkerAktørId: String, pleietrengendeAktørId: String): Boolean =
         omsorgRepository.existsBySøkerAktørIdAndPleietrengendeAktørId(søkerAktørId, pleietrengendeAktørId)

--- a/src/main/kotlin/no/nav/sifinnsynapi/omsorg/OmsorgStatus.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/omsorg/OmsorgStatus.kt
@@ -1,0 +1,8 @@
+package no.nav.sifinnsynapi.omsorg
+
+enum class OmsorgStatus {
+    HAR_OMSORGEN,
+    HAR_IKKE_OMSORGEN,
+    HAR_IKKE_EVALUERT_OMSORGEN
+}
+

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
@@ -24,7 +24,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.util.*
-import java.util.stream.Stream
 
 
 @Service
@@ -84,13 +83,10 @@ class InnsendingService(
         pleietrengendeAktørId: String,
     ): Søknad? {
         return søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(søkersAktørId, pleietrengendeAktørId)
-            .use { søknadStream: Stream<PsbSøknadDAO> ->
-                søknadStream.map { psbSøknadDAO: PsbSøknadDAO ->
-                    JsonUtils.fromString(psbSøknadDAO.søknad, Søknad::class.java)
-                }
-                    .reduce(Søknadsammenslåer::slåSammen)
-                    .orElse(null)
+            .map { psbSøknadDAO: PsbSøknadDAO ->
+                JsonUtils.fromString(psbSøknadDAO.søknad, Søknad::class.java)
             }
+            .reduceOrNull(Søknadsammenslåer::slåSammen)
     }
 
     fun lagreSøknad(søknad: PsbSøknadDAO): PsbSøknadDAO = søknadRepository.save(søknad)

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
@@ -56,7 +56,7 @@ class InnsendingService(
             (oppslagsService.hentSøker()
                 ?: throw IllegalStateException("Feilet med å hente søkers aktørId.")).aktørId
 
-        val søknaderPerPleietrengende = søknadRepository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc(søkersAktørId)
+        val søknaderPerPleietrengende: Map<String, List<PsbSøknadDAO>> = søknadRepository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc(søkersAktørId)
             .groupBy { it.pleietrengendeAktørId }
 
         val allePleietrengendeAktørIder = søknaderPerPleietrengende.keys.toList()
@@ -93,7 +93,7 @@ class InnsendingService(
 
         val sammenslåttSøknad = slåSammenPsbSøknader(psbSøknader) ?: return null
 
-        // Hvis omsorgen ikke har blitt evaluert ennå, annonymiser søknaden
+        // Hvis omsorgen ikke har blitt evaluert ennå, anonymiser søknaden
         if (pleietrengendeSøkerHarOmsorgFor.getValue(pleietrengendeAktørId) == OmsorgStatus.HAR_IKKE_EVALUERT_OMSORGEN) {
             return sammenslåttSøknad.somSøknadDTOMedAnonymisertBarn(pleietrengendeAktørId)
         }

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
@@ -89,8 +89,7 @@ class InnsendingService(
         // Hvis pleietrengende finnes i systemoppslag men søker ikke har omsorg, anonymiser
         val søkerHarOmsorg = pleietrengendeSøkerHarOmsorgFor.contains(pleietrengendeAktørId)
         if (!søkerHarOmsorg) {
-            anonymiserBarnIYtelse(sammenslåttSøknad)
-            return sammenslåttSøknad.somSøknadDTO(anonymisertBarn(pleietrengendeAktørId))
+            return sammenslåttSøknad.somSøknadDTOMedAnonymisertBarn(pleietrengendeAktørId)
         }
 
         return sammenslåttSøknad.somSøknadDTO(barnOppslag)
@@ -103,10 +102,6 @@ class InnsendingService(
             .reduceOrNull(Søknadsammenslåer::slåSammen)
     }
 
-    private fun anonymiserBarnIYtelse(søknad: Søknad) {
-        søknad.getYtelse<PleiepengerSyktBarn>().medBarn(Barn())
-    }
-
     fun lagreSøknad(søknad: PsbSøknadDAO): PsbSøknadDAO = søknadRepository.save(søknad)
 
     @Transactional
@@ -115,12 +110,23 @@ class InnsendingService(
         return !søknadRepository.existsById(journalpostId)
     }
 
-    private fun Søknad.somSøknadDTO(barn: BarnOppslagDTO, alleSøknader: List<Søknad>? = null): SøknadDTO {
+    private fun Søknad.somSøknadDTO(barn: BarnOppslagDTO): SøknadDTO {
         return SøknadDTO(
             barn = barn,
             søknad = this,
-            søknader = alleSøknader
         )
+    }
+
+    private fun Søknad.somSøknadDTOMedAnonymisertBarn(pleietrengendeAktørId: String): SøknadDTO {
+        anonymiserBarnIYtelse(this)
+        return SøknadDTO(
+            barn = anonymisertBarn(pleietrengendeAktørId),
+            søknad = this,
+        )
+    }
+
+    private fun anonymiserBarnIYtelse(søknad: Søknad) {
+        søknad.getYtelse<PleiepengerSyktBarn>().medBarn(Barn())
     }
 
     private fun anonymisertBarn(pleietrengendeAktørId: String): BarnOppslagDTO {
@@ -128,9 +134,7 @@ class InnsendingService(
             aktørId = pleietrengendeAktørId,
             fødselsdato = LocalDate.EPOCH,
             fornavn = "",
-            mellomnavn = null,
             etternavn = "",
-            identitetsnummer = null
         )
     }
 

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
@@ -70,11 +70,11 @@ class InnsendingService(
 
         return søknaderPerPleietrengende
             .mapNotNull { (pleietrengendeAktørId, psbSøknader) ->
-                slåSammenOgMapTilDTO(pleietrengendeAktørId, psbSøknader, barnOppslagDTOS)
+                slåSammenSøknaderOgMapTilDTO(pleietrengendeAktørId, psbSøknader, barnOppslagDTOS)
             }
     }
 
-    private fun slåSammenOgMapTilDTO(
+    private fun slåSammenSøknaderOgMapTilDTO(
         pleietrengendeAktørId: String,
         psbSøknader: List<PsbSøknadDAO>,
         barnOppslagDTOS: List<BarnOppslagDTO>,

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
@@ -3,6 +3,9 @@ package no.nav.sifinnsynapi.soknad
 import no.nav.k9.innsyn.Søknadsammenslåer
 import no.nav.k9.søknad.JsonUtils
 import no.nav.k9.søknad.Søknad
+import no.nav.k9.søknad.felles.personopplysninger.Barn
+import no.nav.k9.søknad.ytelse.Ytelse
+import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarn
 import no.nav.sifinnsynapi.legacy.legacyinnsynapi.LegacyInnsynApiService
 import no.nav.sifinnsynapi.legacy.legacyinnsynapi.LegacySøknadstype
 import no.nav.sifinnsynapi.legacy.legacyinnsynapi.NotSupportedArbeidsgiverMeldingException
@@ -67,14 +70,36 @@ class InnsendingService(
 
         return søknaderPerPleietrengende
             .mapNotNull { (pleietrengendeAktørId, psbSøknader) ->
-                val barn = barnOppslagDTOS.firstOrNull { it.aktørId == pleietrengendeAktørId }
-                    ?: anonymisertBarn(pleietrengendeAktørId)
-
-                psbSøknader
-                    .map { psbSøknadDAO -> JsonUtils.fromString(psbSøknadDAO.søknad, Søknad::class.java) }
-                    .reduceOrNull(Søknadsammenslåer::slåSammen)
-                    ?.somSøknadDTO(barn)
+                slåSammenOgMapTilDTO(pleietrengendeAktørId, psbSøknader, barnOppslagDTOS)
             }
+    }
+
+    private fun slåSammenOgMapTilDTO(
+        pleietrengendeAktørId: String,
+        psbSøknader: List<PsbSøknadDAO>,
+        barnOppslagDTOS: List<BarnOppslagDTO>,
+    ): SøknadDTO? {
+        val barnOppslag = barnOppslagDTOS.firstOrNull { it.aktørId == pleietrengendeAktørId }
+        val barn = barnOppslag ?: anonymisertBarn(pleietrengendeAktørId)
+
+        val sammenslåttSøknad = slåSammenPsbSøknader(psbSøknader) ?: return null
+
+        if (barnOppslag == null) {
+            anonymiserBarnIYtelse(sammenslåttSøknad)
+        }
+
+        return sammenslåttSøknad.somSøknadDTO(barn)
+    }
+
+    private fun slåSammenPsbSøknader(psbSøknader: List<PsbSøknadDAO>): Søknad? {
+        return psbSøknader
+            .map { JsonUtils.fromString(it.søknad, Søknad::class.java) }
+            .filter { it.getYtelse<Ytelse>() is PleiepengerSyktBarn }
+            .reduceOrNull(Søknadsammenslåer::slåSammen)
+    }
+
+    private fun anonymiserBarnIYtelse(søknad: Søknad) {
+        søknad.getYtelse<PleiepengerSyktBarn>().medBarn(Barn())
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
@@ -52,28 +52,28 @@ class InnsendingService(
             (oppslagsService.hentSøker()
                 ?: throw IllegalStateException("Feilet med å hente søkers aktørId.")).aktørId
 
-
         val pleietrengendeSøkerHarOmsorgFor = omsorgService.hentPleietrengendeSøkerHarOmsorgFor(søkersAktørId)
-        if (pleietrengendeSøkerHarOmsorgFor.isEmpty()) {
-            logger.info("Fant ingen pleietrengende søker har omsorgen for.")
-            return listOf()
+
+        val barnOppslagDTOS: List<BarnOppslagDTO> = if (pleietrengendeSøkerHarOmsorgFor.isNotEmpty()) {
+            oppslagsService.systemoppslagBarn(HentBarnForespørsel(identer = pleietrengendeSøkerHarOmsorgFor))
+        } else {
+            emptyList()
         }
 
-        val barnOppslagDTOS: List<BarnOppslagDTO> = oppslagsService.systemoppslagBarn(HentBarnForespørsel(identer = pleietrengendeSøkerHarOmsorgFor))
-        if (barnOppslagDTOS.isEmpty()) {
-            return emptyList()
-        }
         logger.info("Fant {} pleietrengende søker har omsorgen for.", pleietrengendeSøkerHarOmsorgFor.size)
 
-        return pleietrengendeSøkerHarOmsorgFor
-            .mapNotNull { pleietrengendeAktørId ->
+        val søknaderPerPleietrengende = søknadRepository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc(søkersAktørId)
+            .groupBy { it.pleietrengendeAktørId }
+
+        return søknaderPerPleietrengende
+            .mapNotNull { (pleietrengendeAktørId, psbSøknader) ->
                 val barn = barnOppslagDTOS.firstOrNull { it.aktørId == pleietrengendeAktørId }
-                if (barn != null) {
-                    slåSammenSøknaderFor(søkersAktørId, pleietrengendeAktørId)?.somSøknadDTO(barn)
-                } else {
-                    logger.info("PleietrengedeAktørId matchet ikke med aktørId på barn fra oppslag.")
-                    null
-                }
+                    ?: anonymisertBarn(pleietrengendeAktørId)
+
+                psbSøknader
+                    .map { psbSøknadDAO -> JsonUtils.fromString(psbSøknadDAO.søknad, Søknad::class.java) }
+                    .reduceOrNull(Søknadsammenslåer::slåSammen)
+                    ?.somSøknadDTO(barn)
             }
     }
 
@@ -102,6 +102,17 @@ class InnsendingService(
             barn = barn,
             søknad = this,
             søknader = alleSøknader
+        )
+    }
+
+    private fun anonymisertBarn(pleietrengendeAktørId: String): BarnOppslagDTO {
+        return BarnOppslagDTO(
+            aktørId = pleietrengendeAktørId,
+            fødselsdato = LocalDate.EPOCH,
+            fornavn = "",
+            mellomnavn = null,
+            etternavn = "",
+            identitetsnummer = null
         )
     }
 

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
@@ -107,18 +107,6 @@ class InnsendingService(
         søknad.getYtelse<PleiepengerSyktBarn>().medBarn(Barn())
     }
 
-    @Transactional(readOnly = true)
-    fun slåSammenSøknaderFor(
-        søkersAktørId: String,
-        pleietrengendeAktørId: String,
-    ): Søknad? {
-        return søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(søkersAktørId, pleietrengendeAktørId)
-            .map { psbSøknadDAO: PsbSøknadDAO ->
-                JsonUtils.fromString(psbSøknadDAO.søknad, Søknad::class.java)
-            }
-            .reduceOrNull(Søknadsammenslåer::slåSammen)
-    }
-
     fun lagreSøknad(søknad: PsbSøknadDAO): PsbSøknadDAO = søknadRepository.save(søknad)
 
     @Transactional

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
@@ -13,6 +13,7 @@ import no.nav.sifinnsynapi.legacy.legacyinnsynapi.utils.PSBJsonUtils
 import no.nav.sifinnsynapi.legacy.legacyinnsynapi.utils.PSBJsonUtils.finnOrganisasjon
 import no.nav.sifinnsynapi.legacy.legacyinnsynapi.utils.PSBJsonUtils.tilArbeidstakernavn
 import no.nav.sifinnsynapi.omsorg.OmsorgService
+import no.nav.sifinnsynapi.omsorg.OmsorgStatus
 import no.nav.sifinnsynapi.oppslag.BarnOppslagDTO
 import no.nav.sifinnsynapi.oppslag.HentBarnForespørsel
 import no.nav.sifinnsynapi.oppslag.OppslagsService
@@ -55,13 +56,14 @@ class InnsendingService(
             (oppslagsService.hentSøker()
                 ?: throw IllegalStateException("Feilet med å hente søkers aktørId.")).aktørId
 
-        val pleietrengendeSøkerHarOmsorgFor = omsorgService.hentPleietrengendeSøkerHarOmsorgFor(søkersAktørId)
-        logger.info("Fant {} pleietrengende søker har omsorgen for.", pleietrengendeSøkerHarOmsorgFor.size)
-
         val søknaderPerPleietrengende = søknadRepository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc(søkersAktørId)
             .groupBy { it.pleietrengendeAktørId }
 
         val allePleietrengendeAktørIder = søknaderPerPleietrengende.keys.toList()
+
+        val pleietrengendeSøkerHarOmsorgFor: Map<String, OmsorgStatus> = allePleietrengendeAktørIder
+            .associateWith { omsorgService.hentOmsorgStatus(søkersAktørId, it) }
+
         val barnOppslagDTOS: List<BarnOppslagDTO> = if (allePleietrengendeAktørIder.isNotEmpty()) {
             oppslagsService.systemoppslagBarn(HentBarnForespørsel(identer = allePleietrengendeAktørIder))
         } else {
@@ -78,17 +80,21 @@ class InnsendingService(
         pleietrengendeAktørId: String,
         psbSøknader: List<PsbSøknadDAO>,
         barnOppslagDTOS: List<BarnOppslagDTO>,
-        pleietrengendeSøkerHarOmsorgFor: List<String>,
+        pleietrengendeSøkerHarOmsorgFor: Map<String, OmsorgStatus>,
     ): SøknadDTO? {
         // Hvis pleietrengende ikke finnes i systemoppslag, filtrer ut søknaden
         val barnOppslag = barnOppslagDTOS.firstOrNull { it.aktørId == pleietrengendeAktørId }
             ?: return null
 
+        // Hvis søker ikke har omsorgen for, filtrer ut søknaden
+        if (pleietrengendeSøkerHarOmsorgFor.getValue(pleietrengendeAktørId) == OmsorgStatus.HAR_IKKE_OMSORGEN) {
+            return null
+        }
+
         val sammenslåttSøknad = slåSammenPsbSøknader(psbSøknader) ?: return null
 
-        // Hvis pleietrengende finnes i systemoppslag men søker ikke har omsorg, anonymiser
-        val søkerHarOmsorg = pleietrengendeSøkerHarOmsorgFor.contains(pleietrengendeAktørId)
-        if (!søkerHarOmsorg) {
+        // Hvis omsorgen ikke har blitt evaluert ennå, annonymiser søknaden
+        if (pleietrengendeSøkerHarOmsorgFor.getValue(pleietrengendeAktørId) == OmsorgStatus.HAR_IKKE_EVALUERT_OMSORGEN) {
             return sammenslåttSøknad.somSøknadDTOMedAnonymisertBarn(pleietrengendeAktørId)
         }
 

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
@@ -56,21 +56,21 @@ class InnsendingService(
                 ?: throw IllegalStateException("Feilet med å hente søkers aktørId.")).aktørId
 
         val pleietrengendeSøkerHarOmsorgFor = omsorgService.hentPleietrengendeSøkerHarOmsorgFor(søkersAktørId)
-
-        val barnOppslagDTOS: List<BarnOppslagDTO> = if (pleietrengendeSøkerHarOmsorgFor.isNotEmpty()) {
-            oppslagsService.systemoppslagBarn(HentBarnForespørsel(identer = pleietrengendeSøkerHarOmsorgFor))
-        } else {
-            emptyList()
-        }
-
         logger.info("Fant {} pleietrengende søker har omsorgen for.", pleietrengendeSøkerHarOmsorgFor.size)
 
         val søknaderPerPleietrengende = søknadRepository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc(søkersAktørId)
             .groupBy { it.pleietrengendeAktørId }
 
+        val allePleietrengendeAktørIder = søknaderPerPleietrengende.keys.toList()
+        val barnOppslagDTOS: List<BarnOppslagDTO> = if (allePleietrengendeAktørIder.isNotEmpty()) {
+            oppslagsService.systemoppslagBarn(HentBarnForespørsel(identer = allePleietrengendeAktørIder))
+        } else {
+            emptyList()
+        }
+
         return søknaderPerPleietrengende
             .mapNotNull { (pleietrengendeAktørId, psbSøknader) ->
-                slåSammenSøknaderOgMapTilDTO(pleietrengendeAktørId, psbSøknader, barnOppslagDTOS)
+                slåSammenSøknaderOgMapTilDTO(pleietrengendeAktørId, psbSøknader, barnOppslagDTOS, pleietrengendeSøkerHarOmsorgFor)
             }
     }
 
@@ -78,17 +78,22 @@ class InnsendingService(
         pleietrengendeAktørId: String,
         psbSøknader: List<PsbSøknadDAO>,
         barnOppslagDTOS: List<BarnOppslagDTO>,
+        pleietrengendeSøkerHarOmsorgFor: List<String>,
     ): SøknadDTO? {
+        // Hvis pleietrengende ikke finnes i systemoppslag, filtrer ut søknaden
         val barnOppslag = barnOppslagDTOS.firstOrNull { it.aktørId == pleietrengendeAktørId }
-        val barn = barnOppslag ?: anonymisertBarn(pleietrengendeAktørId)
+            ?: return null
 
         val sammenslåttSøknad = slåSammenPsbSøknader(psbSøknader) ?: return null
 
-        if (barnOppslag == null) {
+        // Hvis pleietrengende finnes i systemoppslag men søker ikke har omsorg, anonymiser
+        val søkerHarOmsorg = pleietrengendeSøkerHarOmsorgFor.contains(pleietrengendeAktørId)
+        if (!søkerHarOmsorg) {
             anonymiserBarnIYtelse(sammenslåttSøknad)
+            return sammenslåttSøknad.somSøknadDTO(anonymisertBarn(pleietrengendeAktørId))
         }
 
-        return sammenslåttSøknad.somSøknadDTO(barn)
+        return sammenslåttSøknad.somSøknadDTO(barnOppslag)
     }
 
     private fun slåSammenPsbSøknader(psbSøknader: List<PsbSøknadDAO>): Søknad? {

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/InnsendingService.kt
@@ -83,10 +83,10 @@ class InnsendingService(
         søkersAktørId: String,
         pleietrengendeAktørId: String,
     ): Søknad? {
-        return søknadRepository.findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc(pleietrengendeAktørId)
+        return søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(søkersAktørId, pleietrengendeAktørId)
             .use { søknadStream: Stream<PsbSøknadDAO> ->
                 søknadStream.map { psbSøknadDAO: PsbSøknadDAO ->
-                    psbSøknadDAO.kunPleietrengendeDataFraAndreSøkere(søkersAktørId)
+                    JsonUtils.fromString(psbSøknadDAO.søknad, Søknad::class.java)
                 }
                     .reduce(Søknadsammenslåer::slåSammen)
                     .orElse(null)
@@ -109,13 +109,6 @@ class InnsendingService(
         )
     }
 
-    private fun PsbSøknadDAO.kunPleietrengendeDataFraAndreSøkere(søkerAktørId: String): Søknad {
-        val søknad = JsonUtils.fromString(this.søknad, Søknad::class.java)
-        return when (this.søkerAktørId) {
-            søkerAktørId -> søknad
-            else -> Søknadsammenslåer.kunPleietrengendedata(søknad)
-        }
-    }
 
 
     fun hentArbeidsgiverMeldingFil(søknadId: UUID, organisasjonsnummer: String): ByteArray {

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepository.kt
@@ -5,11 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.transaction.annotation.Transactional
-import java.util.stream.Stream
 
 @Transactional(TRANSACTION_MANAGER)
 interface SøknadRepository : JpaRepository<PsbSøknadDAO, String> {
-    fun findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(søkerAktørId: String, pleietrengendeAktørId: String): Stream<PsbSøknadDAO>
+    fun findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(søkerAktørId: String, pleietrengendeAktørId: String): List<PsbSøknadDAO>
 
     /**
      * Oppdaterer Aktørid for søker (aktørsplitt/merge)

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepository.kt
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @Transactional(TRANSACTION_MANAGER)
 interface SøknadRepository : JpaRepository<PsbSøknadDAO, String> {
+    fun findAllBySøkerAktørIdOrderByOppdatertDatoAsc(søkerAktørId: String): List<PsbSøknadDAO>
     fun findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(søkerAktørId: String, pleietrengendeAktørId: String): List<PsbSøknadDAO>
 
     /**

--- a/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepository.kt
@@ -9,7 +9,7 @@ import java.util.stream.Stream
 
 @Transactional(TRANSACTION_MANAGER)
 interface SøknadRepository : JpaRepository<PsbSøknadDAO, String> {
-    fun findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc(pleietrengendeAktørIder: String): Stream<PsbSøknadDAO>
+    fun findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(søkerAktørId: String, pleietrengendeAktørId: String): Stream<PsbSøknadDAO>
 
     /**
      * Oppdaterer Aktørid for søker (aktørsplitt/merge)

--- a/src/test/kotlin/no/nav/sifinnsynapi/konsument/k9sak/KafkaHendelseKonsumentIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/konsument/k9sak/KafkaHendelseKonsumentIntegrasjonsTest.kt
@@ -21,6 +21,7 @@ import no.nav.sifinnsynapi.config.kafka.Topics.K9_SAK_TOPIC
 import no.nav.sifinnsynapi.omsorg.OmsorgDAO
 import no.nav.sifinnsynapi.omsorg.OmsorgRepository
 import no.nav.sifinnsynapi.omsorg.OmsorgService
+import no.nav.sifinnsynapi.omsorg.OmsorgStatus
 import no.nav.sifinnsynapi.oppslag.BarnOppslagDTO
 import no.nav.sifinnsynapi.oppslag.OppslagsService
 import no.nav.sifinnsynapi.oppslag.SøkerOppslagRespons
@@ -311,9 +312,8 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
         k9SakProducer.leggPåTopic(omsorgHendelseUtenOmsorg, K9_SAK_TOPIC)
 
         await.atMost(Duration.ofSeconds(10)).untilAsserted {
-            val faktiskOmsorg = omsorgService.harOmsorgen(hovedSøkerAktørId, barn1AktørId)
-            assertThat(faktiskOmsorg).isNotNull()
-            assertFalse(faktiskOmsorg)
+            val faktiskOmsorgStatus = omsorgService.hentOmsorgStatus(hovedSøkerAktørId, barn1AktørId)
+            assertEquals(OmsorgStatus.HAR_IKKE_OMSORGEN, faktiskOmsorgStatus)
         }
     }
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/omsorg/OmsorgServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/omsorg/OmsorgServiceTest.kt
@@ -1,17 +1,18 @@
 package no.nav.sifinnsynapi.omsorg
 
-import assertk.assertThat
-import assertk.assertions.isNotNull
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import java.time.Duration
 import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
 
@@ -40,7 +41,7 @@ internal class OmsorgServiceTest {
     }
 
     @Test
-    internal fun `gitt at søker har omsorg for pleiepetrengende, forvent true`() {
+    internal fun `gitt at søker har omsorg for pleiepetrengende, forvent HAR_OMSORGEN`() {
         val søkerAktørId = "11111111111"
         val pleietrengendeAktørId = "22222222222"
         omsorgRepository.save(
@@ -54,17 +55,16 @@ internal class OmsorgServiceTest {
             )
         )
 
-        val harOmsorgen = omsorgService.harOmsorgen(
+        val omsorgStatus = omsorgService.hentOmsorgStatus(
             søkerAktørId = søkerAktørId,
             pleietrengendeAktørId = pleietrengendeAktørId
         )
 
-        assertThat(harOmsorgen).isNotNull()
-        assertTrue { harOmsorgen }
+        assertEquals(OmsorgStatus.HAR_OMSORGEN, omsorgStatus)
     }
 
     @Test
-    internal fun `gitt at søker ikke har omsorg for pleiepetrengende, forvent false`() {
+    internal fun `gitt at søker ikke har omsorg for pleiepetrengende, forvent HAR_IKKE_OMSORGEN`() {
         val søkerAktørId = "11111111111"
         val pleietrengendeAktørId = "22222222222"
         omsorgRepository.save(
@@ -78,16 +78,29 @@ internal class OmsorgServiceTest {
             )
         )
 
-        val harOmsorgen = omsorgService.harOmsorgen(
+        val omsorgStatus = omsorgService.hentOmsorgStatus(
             søkerAktørId = søkerAktørId,
             pleietrengendeAktørId = pleietrengendeAktørId
         )
-        assertThat(harOmsorgen).isNotNull()
-        assertFalse { harOmsorgen }
+
+        assertEquals(OmsorgStatus.HAR_IKKE_OMSORGEN, omsorgStatus)
     }
 
     @Test
-    fun `gitt at omsorg for pleiepetrengende oppdateres, forvent true`() {
+    internal fun `gitt at omsorg ikke er evaluert, forvent HAR_IKKE_EVALUERT_OMSORGEN`() {
+        val søkerAktørId = "11111111111"
+        val pleietrengendeAktørId = "22222222222"
+
+        val omsorgStatus = omsorgService.hentOmsorgStatus(
+            søkerAktørId = søkerAktørId,
+            pleietrengendeAktørId = pleietrengendeAktørId
+        )
+
+        assertEquals(OmsorgStatus.HAR_IKKE_EVALUERT_OMSORGEN, omsorgStatus)
+    }
+
+    @Test
+    fun `gitt at omsorg for pleiepetrengende oppdateres, forvent HAR_OMSORGEN`() {
         val søkerAktørId = "11111111111"
         val pleietrengendeAktørId = "22222222222"
         omsorgRepository.save(
@@ -101,14 +114,17 @@ internal class OmsorgServiceTest {
             )
         )
 
-        val harOmsorgen = omsorgService.harOmsorgen(
+        val omsorgStatus = omsorgService.hentOmsorgStatus(
             søkerAktørId = søkerAktørId,
             pleietrengendeAktørId = pleietrengendeAktørId
         )
-        assertThat(harOmsorgen).isNotNull()
-        assertFalse { harOmsorgen }
+        assertEquals(OmsorgStatus.HAR_IKKE_OMSORGEN, omsorgStatus)
 
         assertTrue { omsorgService.oppdaterOmsorg(søkerAktørId, pleietrengendeAktørId, true) }
-        assertTrue { omsorgService.hentOmsorg(søkerAktørId, pleietrengendeAktørId)!!.harOmsorgen }
+        val omsorgStatus2 = omsorgService.hentOmsorgStatus(
+            søkerAktørId = søkerAktørId,
+            pleietrengendeAktørId = pleietrengendeAktørId
+        )
+        assertEquals(OmsorgStatus.HAR_OMSORGEN, omsorgStatus2)
     }
 }

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceMedMockRepoTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceMedMockRepoTest.kt
@@ -109,7 +109,7 @@ internal class InnsendingServiceMedMockRepoTest {
 
     @Test
     fun `kan slå sammen perioder med tilsyn`() {
-        every { søknadRepository.findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc(any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
             Stream.of(
                 psbSøknadDAO(
                     journalpostId = "1",
@@ -162,7 +162,7 @@ internal class InnsendingServiceMedMockRepoTest {
     @Test
     fun `kan slå sammen arbeidstid for en arbeidstaker`() {
         val org = "987654321"
-        every { søknadRepository.findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc(any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
             Stream.of(
                 psbSøknadDAO(
                     journalpostId = "1",
@@ -221,7 +221,7 @@ internal class InnsendingServiceMedMockRepoTest {
         val org2 = "922222222";
         val org3 = "933333333";
         val org4 = "944444444";
-        every { søknadRepository.findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc(any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
             Stream.of(
                 psbSøknadDAO(
                     journalpostId = "1",
@@ -334,7 +334,7 @@ internal class InnsendingServiceMedMockRepoTest {
 
     @Test
     fun `kan slå sammen arbeidstid for frilanser`() {
-        every { søknadRepository.findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc(any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
             Stream.of(
                 psbSøknadDAO(
                     journalpostId = "1",
@@ -387,7 +387,7 @@ internal class InnsendingServiceMedMockRepoTest {
 
     @Test
     fun `kan slå sammen arbeidstid for selvstendig næringsdrivende`() {
-        every { søknadRepository.findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc(any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
             Stream.of(
                 psbSøknadDAO(
                     journalpostId = "1",
@@ -440,7 +440,7 @@ internal class InnsendingServiceMedMockRepoTest {
 
     @Test
     fun `gitt ingen søknader blir funnet, forvent tom liste`() {
-        every { søknadRepository.findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc(any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
             Stream.empty()
         }
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceMedMockRepoTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceMedMockRepoTest.kt
@@ -29,7 +29,6 @@ import java.time.Duration
 import java.time.LocalDate
 import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
-import java.util.stream.Stream
 
 
 @ExtendWith(SpringExtension::class)
@@ -110,7 +109,7 @@ internal class InnsendingServiceMedMockRepoTest {
     @Test
     fun `kan slå sammen perioder med tilsyn`() {
         every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
-            Stream.of(
+            listOf(
                 psbSøknadDAO(
                     journalpostId = "1",
                     søknad = defaultSøknad(
@@ -163,7 +162,7 @@ internal class InnsendingServiceMedMockRepoTest {
     fun `kan slå sammen arbeidstid for en arbeidstaker`() {
         val org = "987654321"
         every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
-            Stream.of(
+            listOf(
                 psbSøknadDAO(
                     journalpostId = "1",
                     søknad = defaultSøknad(
@@ -222,7 +221,7 @@ internal class InnsendingServiceMedMockRepoTest {
         val org3 = "933333333";
         val org4 = "944444444";
         every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
-            Stream.of(
+            listOf(
                 psbSøknadDAO(
                     journalpostId = "1",
                     søknad = defaultSøknad(
@@ -335,7 +334,7 @@ internal class InnsendingServiceMedMockRepoTest {
     @Test
     fun `kan slå sammen arbeidstid for frilanser`() {
         every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
-            Stream.of(
+            listOf(
                 psbSøknadDAO(
                     journalpostId = "1",
                     søknad = defaultSøknad(
@@ -388,7 +387,7 @@ internal class InnsendingServiceMedMockRepoTest {
     @Test
     fun `kan slå sammen arbeidstid for selvstendig næringsdrivende`() {
         every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
-            Stream.of(
+            listOf(
                 psbSøknadDAO(
                     journalpostId = "1",
                     søknad = defaultSøknad(
@@ -441,7 +440,7 @@ internal class InnsendingServiceMedMockRepoTest {
     @Test
     fun `gitt ingen søknader blir funnet, forvent tom liste`() {
         every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
-            Stream.empty()
+            emptyList()
         }
 
         assertThat(innsendingService.slåSammenSøknadsopplysningerPerBarn()).isEmpty()

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceMedMockRepoTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceMedMockRepoTest.kt
@@ -108,7 +108,7 @@ internal class InnsendingServiceMedMockRepoTest {
 
     @Test
     fun `kan slå sammen perioder med tilsyn`() {
-        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc(any()) } answers {
             listOf(
                 psbSøknadDAO(
                     journalpostId = "1",
@@ -161,7 +161,7 @@ internal class InnsendingServiceMedMockRepoTest {
     @Test
     fun `kan slå sammen arbeidstid for en arbeidstaker`() {
         val org = "987654321"
-        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc(any()) } answers {
             listOf(
                 psbSøknadDAO(
                     journalpostId = "1",
@@ -220,7 +220,7 @@ internal class InnsendingServiceMedMockRepoTest {
         val org2 = "922222222";
         val org3 = "933333333";
         val org4 = "944444444";
-        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc(any()) } answers {
             listOf(
                 psbSøknadDAO(
                     journalpostId = "1",
@@ -333,7 +333,7 @@ internal class InnsendingServiceMedMockRepoTest {
 
     @Test
     fun `kan slå sammen arbeidstid for frilanser`() {
-        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc(any()) } answers {
             listOf(
                 psbSøknadDAO(
                     journalpostId = "1",
@@ -386,7 +386,7 @@ internal class InnsendingServiceMedMockRepoTest {
 
     @Test
     fun `kan slå sammen arbeidstid for selvstendig næringsdrivende`() {
-        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc(any()) } answers {
             listOf(
                 psbSøknadDAO(
                     journalpostId = "1",
@@ -439,7 +439,7 @@ internal class InnsendingServiceMedMockRepoTest {
 
     @Test
     fun `gitt ingen søknader blir funnet, forvent tom liste`() {
-        every { søknadRepository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc(any(), any()) } answers {
+        every { søknadRepository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc(any()) } answers {
             emptyList()
         }
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
@@ -170,6 +170,8 @@ internal class InnsendingServiceTest {
 
     @Test
     fun `gitt søknader med tilsyn og arbeidstid fra flere søkere på samme barn, forvent kun data fra innlogget søker`() {
+        omsorgRepository.oppdaterOmsorg(true, hovedSøkerAktørId, barn1AktørId)
+
         val organisasjonsnummer = "987654321"
 
         // gitt at det eksiterer to søknader med arbeidstid og omsorgstilbud fra 2 søkere på samme barn...
@@ -277,7 +279,7 @@ internal class InnsendingServiceTest {
     }
 
     @Test
-    fun `gitt at søker ikke har omsorg for barna, forvent anonymisert resultat`() {
+    fun `gitt at søker ikke har omsorg for barna, forvent tom liste`() {
         omsorgRepository.oppdaterOmsorg(false, hovedSøkerAktørId, barn1AktørId)
         omsorgRepository.oppdaterOmsorg(false, hovedSøkerAktørId, barn2AktørId)
 
@@ -292,6 +294,26 @@ internal class InnsendingServiceTest {
                 hovedSøkerAktørId,
                 barn2AktørId
             )!!.harOmsorgen
+        )
+
+        assertThat(innsendingService.slåSammenSøknadsopplysningerPerBarn()).isEmpty()
+    }
+
+    @Test
+    fun `gitt at søker ikke har fått evaluert omsorge for ennå, forvent anonymisert resultat`() {
+        omsorgRepository.deleteAll()
+
+        assertNull(
+            omsorgRepository.findBySøkerAktørIdAndPleietrengendeAktørId(
+                hovedSøkerAktørId,
+                barn1AktørId
+            )?.harOmsorgen
+        )
+        assertNull(
+            omsorgRepository.findBySøkerAktørIdAndPleietrengendeAktørId(
+                hovedSøkerAktørId,
+                barn2AktørId
+            )?.harOmsorgen
         )
 
         val resultat = innsendingService.slåSammenSøknadsopplysningerPerBarn()

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
@@ -18,7 +18,9 @@ import no.nav.sifinnsynapi.legacy.legacyinnsynapi.LegacySøknadNotFoundException
 import no.nav.sifinnsynapi.legacy.legacyinnsynapi.LegacySøknadstype
 import no.nav.sifinnsynapi.omsorg.OmsorgDAO
 import no.nav.sifinnsynapi.omsorg.OmsorgRepository
-import no.nav.sifinnsynapi.oppslag.*
+import no.nav.sifinnsynapi.oppslag.BarnOppslagDTO
+import no.nav.sifinnsynapi.oppslag.OppslagsService
+import no.nav.sifinnsynapi.oppslag.SøkerOppslagRespons
 import no.nav.sifinnsynapi.utils.*
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
@@ -268,13 +270,12 @@ internal class InnsendingServiceTest {
 
     @Test
     fun `gitt at søker ikke har barn, forvent tom liste`() {
-        every { oppslagsService.hentBarn() } answers { listOf() }
+        every { oppslagsService.systemoppslagBarn(any()) } returns emptyList()
         assertThat(innsendingService.slåSammenSøknadsopplysningerPerBarn()).isEmpty()
     }
 
     @Test
-    //@Disabled("Har deaktivert sjekk på omsorg i SøknadService.kt:28")
-    fun `gitt at søker ikke har omsorg for barna, forvent tom liste`() {
+    fun `gitt at søker ikke har omsorg for barna, forvent anonymisert resultat`() {
         omsorgRepository.oppdaterOmsorg(false, hovedSøkerAktørId, barn1AktørId)
         omsorgRepository.oppdaterOmsorg(false, hovedSøkerAktørId, barn2AktørId)
 
@@ -291,8 +292,25 @@ internal class InnsendingServiceTest {
             )!!.harOmsorgen
         )
 
-        assertThat(innsendingService.slåSammenSøknadsopplysningerPerBarn()).isEmpty()
+        val resultat = innsendingService.slåSammenSøknadsopplysningerPerBarn()
+        assertThat(resultat).isNotEmpty
+        assertThat(resultat).size().isEqualTo(1)
 
+        val søknadDTO = resultat.first()
+
+        // Forvent at BarnOppslagDTO er anonymisert
+        assertThat(søknadDTO.barn.fornavn).isEmpty()
+        assertThat(søknadDTO.barn.etternavn).isEmpty()
+        assertThat(søknadDTO.barn.mellomnavn).isNull()
+        assertThat(søknadDTO.barn.identitetsnummer).isNull()
+        assertThat(søknadDTO.barn.fødselsdato).isEqualTo(LocalDate.EPOCH)
+        assertThat(søknadDTO.barn.aktørId).isEqualTo(barn1AktørId)
+
+        // Forvent at Barn i ytelsen også er anonymisert
+        assertNotNull(søknadDTO.søknad)
+        val ytelse = søknadDTO.søknad.getYtelse<PleiepengerSyktBarn>()
+        assertThat(ytelse.barn.personIdent).isNull()
+        assertThat(ytelse.barn.fødselsdato).isNull()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
@@ -237,7 +237,11 @@ internal class InnsendingServiceTest {
         )
 
         // forvent at kun søknader fra innlogget søker blir returnert.
-        val søknad: Søknad? = innsendingService.slåSammenSøknaderFor(hovedSøkerAktørId, barn1AktørId)
+        val søknader = innsendingService.slåSammenSøknadsopplysningerPerBarn()
+        assertThat(søknader).isNotEmpty
+        assertThat(søknader).size().isEqualTo(1)
+
+        val søknad: Søknad? = søknader.firstOrNull()?.søknad
         assertNotNull(søknad)
 
         val ytelse = søknad!!.getYtelse<PleiepengerSyktBarn>()

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
@@ -300,7 +300,7 @@ internal class InnsendingServiceTest {
     }
 
     @Test
-    fun `gitt at søker ikke har fått evaluert omsorge for ennå, forvent anonymisert resultat`() {
+    fun `gitt at søker ikke har fått evaluert omsorg for ennå, forvent anonymisert resultat`() {
         omsorgRepository.deleteAll()
 
         assertNull(

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
@@ -169,7 +169,7 @@ internal class InnsendingServiceTest {
     }
 
     @Test
-    fun `gitt søknader med tilsyn og arbeidstid fra flere søkere på samme barn, forvent kun at tilsynsperioder blir slått sammen`() {
+    fun `gitt søknader med tilsyn og arbeidstid fra flere søkere på samme barn, forvent kun data fra innlogget søker`() {
         val organisasjonsnummer = "987654321"
 
         // gitt at det eksiterer to søknader med arbeidstid og omsorgstilbud fra 2 søkere på samme barn...
@@ -234,7 +234,7 @@ internal class InnsendingServiceTest {
             )
         )
 
-        // forvent at søknadene blir slått sammen.
+        // forvent at kun søknader fra innlogget søker blir returnert.
         val søknad: Søknad? = innsendingService.slåSammenSøknaderFor(hovedSøkerAktørId, barn1AktørId)
         assertNotNull(søknad)
 
@@ -256,14 +256,12 @@ internal class InnsendingServiceTest {
             )
         )
 
-        // Samt, at periodene med omsorgstilbd fra de to søknadene med forskjellige søkere er slått sammen.
+        // Tilsynsordning skal kun inneholde perioder fra innlogget søker, ikke fra andre søkere.
         assertResultet(
             faktiskePerioder = sammenslåttTilsynsordning.perioder,
             forventedePerioder = mapOf(
-                Periode(LocalDate.parse("2021-08-01"), LocalDate.parse("2021-09-24")) to
-                        TilsynPeriodeInfo().medEtablertTilsynTimerPerDag(Duration.ofHours(4)),
-                Periode(LocalDate.parse("2021-09-25"), LocalDate.parse("2021-12-01")) to
-                        TilsynPeriodeInfo().medEtablertTilsynTimerPerDag(Duration.ofHours(2).plusMinutes(30))
+                Periode(LocalDate.parse("2021-08-01"), LocalDate.parse("2021-10-11")) to
+                        TilsynPeriodeInfo().medEtablertTilsynTimerPerDag(Duration.ofHours(4))
             )
         )
     }

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepositoryTest.kt
@@ -51,9 +51,9 @@ class SøknadRepositoryTest {
     }
 
     @Test
-    fun `hent alle søknader som stream`() {
+    fun `hent alle søknader`() {
         assertNotNull(repository.save(lagSøknadDAO()))
-        assertk.assertThat(repository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc("12345678910", "10987654321").count())
+        assertk.assertThat(repository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc("12345678910", "10987654321").size)
             .isEqualTo(1)
     }
 
@@ -65,13 +65,13 @@ class SøknadRepositoryTest {
     }
 
     @Test
-    fun `hent 1000 søknader som en strøm`() {
+    fun `hent 1000 søknader`() {
         IntStream.range(0, 1000).forEach {
             repository.save(lagSøknadDAO(journalpostId = it.toString()))
         }
-        repository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc("12345678910", "10987654321").use {
-            assertk.assertThat(it.count()).isEqualTo(1000)
-        }
+        assertk.assertThat(
+            repository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc("12345678910", "10987654321").size
+        ).isEqualTo(1000)
     }
 
     private fun lagSøknadDAO(

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepositoryTest.kt
@@ -58,6 +58,14 @@ class SøknadRepositoryTest {
     }
 
     @Test
+    fun `hent alle søknader kun med søkers aktørId`() {
+        repository.save(lagSøknadDAO(journalpostId = "00000000001", pleietrengendeAktørId = "10987654321"))
+        repository.save(lagSøknadDAO(journalpostId = "00000000002", pleietrengendeAktørId = "10987654322"))
+        assertk.assertThat(repository.findAllBySøkerAktørIdOrderByOppdatertDatoAsc("12345678910").size)
+            .isEqualTo(2)
+    }
+
+    @Test
     fun `oppdater aktørid`() {
         assertNotNull(repository.save(lagSøknadDAO()))
         assertk.assertThat(repository.oppdaterAktørIdForSøker("12345678911","12345678910"))

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepositoryTest.kt
@@ -53,7 +53,7 @@ class SøknadRepositoryTest {
     @Test
     fun `hent alle søknader som stream`() {
         assertNotNull(repository.save(lagSøknadDAO()))
-        assertk.assertThat(repository.findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc("10987654321").count())
+        assertk.assertThat(repository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc("12345678910", "10987654321").count())
             .isEqualTo(1)
     }
 
@@ -69,7 +69,7 @@ class SøknadRepositoryTest {
         IntStream.range(0, 1000).forEach {
             repository.save(lagSøknadDAO(journalpostId = it.toString()))
         }
-        repository.findAllByPleietrengendeAktørIdOrderByOppdatertDatoAsc("10987654321").use {
+        repository.findAllBySøkerAktørIdAndPleietrengendeAktørIdOrderByOppdatertDatoAsc("12345678910", "10987654321").use {
             assertk.assertThat(it.count()).isEqualTo(1000)
         }
     }

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadSammenslåerTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadSammenslåerTest.kt
@@ -24,6 +24,7 @@ class SøknadSammenslåerTest {
             .orElse(null)
 
         println("Sammenslått søknad: ${JsonUtils.toString(sammenslåttSøknad)}")
+
     }
 }
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadSammenslåerTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadSammenslåerTest.kt
@@ -17,11 +17,9 @@ class SøknadSammenslåerTest {
     @Test
     @Disabled("Kjør lokalt for å feilsøke sammenslåtte søknader")
     fun test() {
-        val søkerIdent = TODO("Fyll inn søkerident her")
         val søknadList = jsonToSøknad()
         println("Slår sammen ${søknadList.size} søknader")
         val sammenslåttSøknad = søknadList.stream()
-            .map { søknad -> kunPleietrengendeDataFraAndreSøkere(søkerIdent, søknad) }
             .reduce(Søknadsammenslåer::slåSammen)
             .orElse(null)
 
@@ -29,11 +27,6 @@ class SøknadSammenslåerTest {
     }
 }
 
-private fun kunPleietrengendeDataFraAndreSøkere(søkerIdent: String, søknad: Søknad) =
-    when (søknad.søker.personIdent.verdi) {
-        søkerIdent -> søknad
-        else -> Søknadsammenslåer.kunPleietrengendedata(søknad)
-    }
 
 fun jsonToSøknad(): List<Søknad> {
     //language=json


### PR DESCRIPTION
### **Behov / Bakgrunn**
1. Vi ønsker ikke å vise omsorgstilbud som kommer fra annen part, selv om det påvirker søkers sak.
2. Hvis k9-sak venter på inntektsmelding blir ikke omsorgen for barnet vurdert. Da får vi ingen saker fra `/soknad`. Vi ønsker  å anonymisere informasjonen om den pleietrengende hvis bruker ikke har evaluert omsorgen for.
3. Hvis søker har evaluert omsorgen for og har **ikke** omsorgen for, skal søknadene for den pleietrengende filtreres bort.


### **Løsning**
1. Fjerner sammenslåing av omsorgstilbud fra annen part.
2. Snur litt om på rekkefølgen ved henting av søknader for å anonymisere of filtrere riktig: 
  a. Henter saker basert på søkerId i stedet for pleietrengendeId (som ikke finnes hvis omsorgenFor ikke er vurdert)
  b. Innfører en OmsorgStatus som forteller om søker HAR_OMSORGEN, HAR_IKKE_OMSORGEN eller HAR_IKKE_EVALUERT_OMSORGEN
  c. Filtrerer bort saker som hvor pleietrengende ikke er barn av søker eller hvor søker ikke har omsorgen.
  d. Anonymiserer barn/pleietrengende hvis søker ikke har fått evaluert omsorgen for ennå.

### Andre endringer
Legger til bin/ i .gitignore