### PR TITLE
Downgrade spring boot

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "4.0.5"
+    id("org.springframework.boot") version "4.0.3"
     id("io.spring.dependency-management") version "1.1.7"
     id("com.expediagroup.graphql") version "9.1.0"
     kotlin("jvm") version "2.3.20"


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ny version av spring boot gjør at vi bruker jackson 3, noe vi ikke er rigget for helt ennå.

### **Løsning**
Downgrader, tilsvarende som https://github.com/navikt/k9-sak-innsyn-api/pull/503
