### PR TITLE
Erstatter ikke-godkjente fødselsnummer med fiktive FNR fra godkjent liste

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -175,7 +175,7 @@ class SwaggerConfiguration(
                                     "ytelse": {
                                       "type": "PLEIEPENGER_SYKT_BARN",
                                       "barn": {
-                                        "norskIdentitetsnummer": "21121879023",
+                                        "norskIdentitetsnummer": "01017000299",
                                         "fødselsdato": null
                                       },
                                       "søknadsperiode": [
@@ -267,7 +267,7 @@ class SwaggerConfiguration(
                                     },
                                     "ytelse": "PLEIEPENGER_SYKT_BARN",
                                     "pleietrengende": {
-                                      "norskIdentitetsnummer": "21121879023"
+                                      "norskIdentitetsnummer": "01017000299"
                                     },
                                     "type": "LEGEERKLÆRING"
                                   },
@@ -387,7 +387,7 @@ class SwaggerConfiguration(
                     "ytelse": {
                       "type": "PLEIEPENGER_SYKT_BARN",
                       "barn": {
-                        "norskIdentitetsnummer": "21121879023",
+                        "norskIdentitetsnummer": "01017000299",
                         "fødselsdato": null
                       },
                       "søknadsperiode": [
@@ -479,7 +479,7 @@ class SwaggerConfiguration(
                     },
                     "ytelse": "PLEIEPENGER_SYKT_BARN",
                     "pleietrengende": {
-                      "norskIdentitetsnummer": "21121879023"
+                      "norskIdentitetsnummer": "01017000299"
                     },
                     "type": "LEGEERKLÆRING"
                   },

--- a/src/test/kotlin/no/nav/sifinnsynapi/konsument/k9sak/KafkaHendelseKonsumentIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/konsument/k9sak/KafkaHendelseKonsumentIntegrasjonsTest.kt
@@ -125,7 +125,7 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             ),
             BarnOppslagDTO(
                 aktørId = barn2AktørId,
@@ -133,7 +133,7 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
                 fornavn = "Dole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "30100577255"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -389,7 +389,7 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
                     "ettersendelse" : {
                         "mottattDato" : "2024-05-03T09:28:21.201Z",
                         "søker" : {
-                            "norskIdentitetsnummer" : "14026223262"
+                            "norskIdentitetsnummer" : "01017000299"
                         },
                         "søknadId" : "67bcff24-82ec-47d9-a39b-2dae93c9bf64",
                         "ytelse" : "PLEIEPENGER_SYKT_BARN"
@@ -401,7 +401,7 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
                       "mottattDato" : "2024-05-03T09:28:21.201Z",
                       "språk" : "nb",
                       "søker" : {
-                        "norskIdentitetsnummer" : "14026223262"
+                        "norskIdentitetsnummer" : "01017000299"
                       },
                       "søknadId" : "67bcff24-82ec-47d9-a39b-2dae93c9bf64",
                       "versjon" : "1.0.0",
@@ -427,7 +427,7 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
                         },
                         "barn" : {
                           "fødselsdato" : null,
-                          "norskIdentitetsnummer" : "21121879023"
+                          "norskIdentitetsnummer" : "01017000299"
                         },
                         "beredskap" : {
                           "perioder" : { },

--- a/src/test/kotlin/no/nav/sifinnsynapi/sak/SakControllerTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/sak/SakControllerTest.kt
@@ -177,7 +177,7 @@ class SakControllerTest {
                                     k9FormatInnsendelse = defaultEttersendelse(
                                         søknadId = søknadId,
                                         søkersIdentitetsnummer = "1234567890",
-                                        pleietrengendeIdentitetsnummer = "21121879023",
+                                        pleietrengendeIdentitetsnummer = "01017000299",
                                         mottattDato = mottattDato
                                     ),
                                     dokumenter = listOf(
@@ -287,7 +287,7 @@ class SakControllerTest {
                                     "ytelse": {
                                       "type": "PLEIEPENGER_SYKT_BARN",
                                       "barn": {
-                                        "norskIdentitetsnummer": "21121879023",
+                                        "norskIdentitetsnummer": "01017000299",
                                         "fødselsdato": null
                                       },
                                       "erSammenMedBarnet": null,
@@ -381,7 +381,7 @@ class SakControllerTest {
                                     },
                                     "ytelse": "PLEIEPENGER_SYKT_BARN",
                                     "pleietrengende": {
-                                      "norskIdentitetsnummer": "21121879023"
+                                      "norskIdentitetsnummer": "01017000299"
                                     },
                                     "type": "LEGEERKLÆRING"
                                   },

--- a/src/test/kotlin/no/nav/sifinnsynapi/sak/SakServiceITest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/sak/SakServiceITest.kt
@@ -81,7 +81,7 @@ class SakServiceITest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             ),
             BarnOppslagDTO(
                 aktørId = barn2AktørId,
@@ -89,7 +89,7 @@ class SakServiceITest {
                 fornavn = "Dole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "30100577255"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -137,7 +137,7 @@ class SakServiceITest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -196,7 +196,7 @@ class SakServiceITest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             )
         )
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/sak/SakServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/sak/SakServiceTest.kt
@@ -74,7 +74,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             ),
             BarnOppslagDTO(
                 aktørId = barn2AktørId,
@@ -82,7 +82,7 @@ class SakServiceTest {
                 fornavn = "Dole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "30100577255"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -103,7 +103,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -149,7 +149,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -204,7 +204,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -268,7 +268,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -325,7 +325,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -386,7 +386,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -439,7 +439,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -484,7 +484,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             )
         )
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceMedMockRepoTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceMedMockRepoTest.kt
@@ -68,7 +68,7 @@ internal class InnsendingServiceMedMockRepoTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             ),
             BarnOppslagDTO(
                 aktørId = barn2AktørId,
@@ -76,7 +76,7 @@ internal class InnsendingServiceMedMockRepoTest {
                 fornavn = "Dole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "30100577255"
+                identitetsnummer = "01017000299"
             )
         )
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
@@ -81,7 +81,7 @@ internal class InnsendingServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "12020567099"
+                identitetsnummer = "01017000299"
             ),
             BarnOppslagDTO(
                 aktørId = barn2AktørId,
@@ -89,7 +89,7 @@ internal class InnsendingServiceTest {
                 fornavn = "Dole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "30100577255"
+                identitetsnummer = "01017000299"
             )
         )
 
@@ -325,7 +325,7 @@ internal class InnsendingServiceTest {
                       "mellomnavn": "Mellomnavn",
                       "etternavn": "Nordmann",
                       "aktørId": "123456",
-                      "fødselsnummer": "02119970078",
+                      "fødselsnummer": "01017000299",
                       "fornavn": "Ola"
                     },
                     "arbeidsgivere": {
@@ -377,7 +377,7 @@ internal class InnsendingServiceTest {
                       "mellomnavn": "Mellomnavn",
                       "etternavn": "Nordmann",
                       "aktørId": "123456",
-                      "fødselsnummer": "02119970078",
+                      "fødselsnummer": "01017000299",
                       "fornavn": "Ola"
                     },
                     "arbeidsgivere": [

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadControllerTest.kt
@@ -102,7 +102,7 @@ class SøknadControllerTest {
                     mellomnavn = null,
                     etternavn = "Nordmann",
                     aktørId = "123",
-                    identitetsnummer = "12020567099",
+                    identitetsnummer = "01017000299",
                     adressebeskyttelse = listOf(
                         Adressebeskyttelse(gradering = AdressebeskyttelseGradering.STRENGT_FORTROLIG)
                     )

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepositoryTest.kt
@@ -77,7 +77,7 @@ class SøknadRepositoryTest {
     private fun lagSøknadDAO(
         søknadId: UUID = UUID.randomUUID(),
         journalpostId: String = "00000000001",
-        søkerPersonIdentifikator: String = "14026223262",
+        søkerPersonIdentifikator: String = "01017000299",
         søkerAktørId: String = "12345678910",
         pleietrengendeAktørId: String = "10987654321",
     ): PsbSøknadDAO = PsbSøknadDAO(

--- a/src/test/kotlin/no/nav/sifinnsynapi/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/utils/SøknadUtils.kt
@@ -97,7 +97,7 @@ fun defaultSøknadTrukket(
 fun defaultSøknad(
     søknadId: UUID = UUID.randomUUID(),
     søknadsPeriode: Periode = Periode(LocalDate.now().plusDays(5), LocalDate.now().plusDays(5)),
-    søkersIdentitetsnummer: String = "14026223262",
+    søkersIdentitetsnummer: String = "01017000299",
     arbeidstid: Arbeidstid? = Arbeidstid().medArbeidstaker(listOf(defaultArbeidstid(listOf(søknadsPeriode)))),
     tilsynsordning: Tilsynsordning? = defaultTilsynsordning(
         mapOf(
@@ -124,7 +124,7 @@ fun defaultSøknad(
 
 fun defaultEttersendelse(
     søknadId: UUID = UUID.randomUUID(),
-    søkersIdentitetsnummer: String = "14026223262",
+    søkersIdentitetsnummer: String = "01017000299",
     pleietrengendeIdentitetsnummer: String = "24026223267",
     mottattDato: ZonedDateTime = ZonedDateTime.now()
 ): Ettersendelse = Ettersendelse.builder()
@@ -139,7 +139,7 @@ fun defaultEttersendelse(
 
 fun defaultPleiepengerSyktBarn(
     søknadsPeriode: Periode = Periode(LocalDate.now().plusDays(5), LocalDate.now().plusDays(5)),
-    barnNorskIdentitetsnummer: String = "21121879023",
+    barnNorskIdentitetsnummer: String = "01017000299",
     arbeidstid: Arbeidstid? = Arbeidstid().medArbeidstaker(listOf(defaultArbeidstid(listOf(søknadsPeriode)))),
     tilsynsordning: Tilsynsordning? = defaultTilsynsordning(
         mapOf(

--- a/src/test/resources/__files/barn.json
+++ b/src/test/resources/__files/barn.json
@@ -2,7 +2,7 @@
   "barn": [
     {
       "aktør_id": "22222222222",
-      "identitetsnummer": "12020567099",
+      "identitetsnummer": "01017000299",
       "fødselsdato": "2005-02-12",
       "fornavn": "Ole,",
       "mellomnavn": null,
@@ -10,7 +10,7 @@
     },
     {
       "aktør_id": "33333333333",
-      "identitetsnummer": "30100577255",
+      "identitetsnummer": "01017000299",
       "fødselsdato": "2005-10-30",
       "fornavn": "Dole,",
       "mellomnavn": null,


### PR DESCRIPTION
## Erstatter ikke-godkjente fødselsnummer

Bytter ut fødselsnummer som ikke er på [godkjent liste](https://github.com/navikt/sif-gha-workflows/tree/main/.github/actions/sif-code-scan/allowed-fnr) med fiktive fødselsnummer fra sif-gha-workflows allowed-fnr.

Dette sikrer at `sif-code-scan` ikke feiler i CI/CD-pipeline.