### PR TITLE
Erstatt fiktive fødselsnummer med syntetisk fnr

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/SwaggerConfiguration.kt
@@ -175,7 +175,7 @@ class SwaggerConfiguration(
                                     "ytelse": {
                                       "type": "PLEIEPENGER_SYKT_BARN",
                                       "barn": {
-                                        "norskIdentitetsnummer": "01017000299",
+                                        "norskIdentitetsnummer": "23500180528",
                                         "fødselsdato": null
                                       },
                                       "søknadsperiode": [
@@ -267,7 +267,7 @@ class SwaggerConfiguration(
                                     },
                                     "ytelse": "PLEIEPENGER_SYKT_BARN",
                                     "pleietrengende": {
-                                      "norskIdentitetsnummer": "01017000299"
+                                      "norskIdentitetsnummer": "23500180528"
                                     },
                                     "type": "LEGEERKLÆRING"
                                   },
@@ -387,7 +387,7 @@ class SwaggerConfiguration(
                     "ytelse": {
                       "type": "PLEIEPENGER_SYKT_BARN",
                       "barn": {
-                        "norskIdentitetsnummer": "01017000299",
+                        "norskIdentitetsnummer": "23500180528",
                         "fødselsdato": null
                       },
                       "søknadsperiode": [
@@ -479,7 +479,7 @@ class SwaggerConfiguration(
                     },
                     "ytelse": "PLEIEPENGER_SYKT_BARN",
                     "pleietrengende": {
-                      "norskIdentitetsnummer": "01017000299"
+                      "norskIdentitetsnummer": "23500180528"
                     },
                     "type": "LEGEERKLÆRING"
                   },

--- a/src/test/kotlin/no/nav/sifinnsynapi/konsument/k9sak/KafkaHendelseKonsumentIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/konsument/k9sak/KafkaHendelseKonsumentIntegrasjonsTest.kt
@@ -126,7 +126,7 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             ),
             BarnOppslagDTO(
                 aktørId = barn2AktørId,
@@ -134,7 +134,7 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
                 fornavn = "Dole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -389,7 +389,7 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
                     "ettersendelse" : {
                         "mottattDato" : "2024-05-03T09:28:21.201Z",
                         "søker" : {
-                            "norskIdentitetsnummer" : "01017000299"
+                            "norskIdentitetsnummer" : "23500180528"
                         },
                         "søknadId" : "67bcff24-82ec-47d9-a39b-2dae93c9bf64",
                         "ytelse" : "PLEIEPENGER_SYKT_BARN"
@@ -401,7 +401,7 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
                       "mottattDato" : "2024-05-03T09:28:21.201Z",
                       "språk" : "nb",
                       "søker" : {
-                        "norskIdentitetsnummer" : "01017000299"
+                        "norskIdentitetsnummer" : "23500180528"
                       },
                       "søknadId" : "67bcff24-82ec-47d9-a39b-2dae93c9bf64",
                       "versjon" : "1.0.0",
@@ -427,7 +427,7 @@ class KafkaHendelseKonsumentIntegrasjonsTest {
                         },
                         "barn" : {
                           "fødselsdato" : null,
-                          "norskIdentitetsnummer" : "01017000299"
+                          "norskIdentitetsnummer" : "23500180528"
                         },
                         "beredskap" : {
                           "perioder" : { },

--- a/src/test/kotlin/no/nav/sifinnsynapi/sak/SakControllerTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/sak/SakControllerTest.kt
@@ -177,7 +177,7 @@ class SakControllerTest {
                                     k9FormatInnsendelse = defaultEttersendelse(
                                         søknadId = søknadId,
                                         søkersIdentitetsnummer = "1234567890",
-                                        pleietrengendeIdentitetsnummer = "01017000299",
+                                        pleietrengendeIdentitetsnummer = "23500180528",
                                         mottattDato = mottattDato
                                     ),
                                     dokumenter = listOf(
@@ -287,7 +287,7 @@ class SakControllerTest {
                                     "ytelse": {
                                       "type": "PLEIEPENGER_SYKT_BARN",
                                       "barn": {
-                                        "norskIdentitetsnummer": "01017000299",
+                                        "norskIdentitetsnummer": "23500180528",
                                         "fødselsdato": null
                                       },
                                       "erSammenMedBarnet": null,
@@ -381,7 +381,7 @@ class SakControllerTest {
                                     },
                                     "ytelse": "PLEIEPENGER_SYKT_BARN",
                                     "pleietrengende": {
-                                      "norskIdentitetsnummer": "01017000299"
+                                      "norskIdentitetsnummer": "23500180528"
                                     },
                                     "type": "LEGEERKLÆRING"
                                   },

--- a/src/test/kotlin/no/nav/sifinnsynapi/sak/SakServiceITest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/sak/SakServiceITest.kt
@@ -81,7 +81,7 @@ class SakServiceITest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             ),
             BarnOppslagDTO(
                 aktørId = barn2AktørId,
@@ -89,7 +89,7 @@ class SakServiceITest {
                 fornavn = "Dole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -137,7 +137,7 @@ class SakServiceITest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -196,7 +196,7 @@ class SakServiceITest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/sak/SakServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/sak/SakServiceTest.kt
@@ -74,7 +74,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             ),
             BarnOppslagDTO(
                 aktørId = barn2AktørId,
@@ -82,7 +82,7 @@ class SakServiceTest {
                 fornavn = "Dole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -103,7 +103,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -149,7 +149,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -204,7 +204,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -268,7 +268,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -325,7 +325,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -386,7 +386,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -439,7 +439,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -484,7 +484,7 @@ class SakServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceMedMockRepoTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceMedMockRepoTest.kt
@@ -67,7 +67,7 @@ internal class InnsendingServiceMedMockRepoTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             ),
             BarnOppslagDTO(
                 aktørId = barn2AktørId,
@@ -75,7 +75,7 @@ internal class InnsendingServiceMedMockRepoTest {
                 fornavn = "Dole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/InnsendingServiceTest.kt
@@ -81,7 +81,7 @@ internal class InnsendingServiceTest {
                 fornavn = "Ole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             ),
             BarnOppslagDTO(
                 aktørId = barn2AktørId,
@@ -89,7 +89,7 @@ internal class InnsendingServiceTest {
                 fornavn = "Dole",
                 mellomnavn = null,
                 etternavn = "Doffen",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
 
@@ -365,7 +365,7 @@ internal class InnsendingServiceTest {
                       "mellomnavn": "Mellomnavn",
                       "etternavn": "Nordmann",
                       "aktørId": "123456",
-                      "fødselsnummer": "01017000299",
+                      "fødselsnummer": "23500180528",
                       "fornavn": "Ola"
                     },
                     "arbeidsgivere": {
@@ -417,7 +417,7 @@ internal class InnsendingServiceTest {
                       "mellomnavn": "Mellomnavn",
                       "etternavn": "Nordmann",
                       "aktørId": "123456",
-                      "fødselsnummer": "01017000299",
+                      "fødselsnummer": "23500180528",
                       "fornavn": "Ola"
                     },
                     "arbeidsgivere": [

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadControllerTest.kt
@@ -102,7 +102,7 @@ class SøknadControllerTest {
                     mellomnavn = null,
                     etternavn = "Nordmann",
                     aktørId = "123",
-                    identitetsnummer = "01017000299",
+                    identitetsnummer = "23500180528",
                     adressebeskyttelse = listOf(
                         Adressebeskyttelse(gradering = AdressebeskyttelseGradering.STRENGT_FORTROLIG)
                     )

--- a/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/soknad/SøknadRepositoryTest.kt
@@ -85,7 +85,7 @@ class SøknadRepositoryTest {
     private fun lagSøknadDAO(
         søknadId: UUID = UUID.randomUUID(),
         journalpostId: String = "00000000001",
-        søkerPersonIdentifikator: String = "01017000299",
+        søkerPersonIdentifikator: String = "23500180528",
         søkerAktørId: String = "12345678910",
         pleietrengendeAktørId: String = "10987654321",
     ): PsbSøknadDAO = PsbSøknadDAO(

--- a/src/test/kotlin/no/nav/sifinnsynapi/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/utils/SøknadUtils.kt
@@ -97,7 +97,7 @@ fun defaultSøknadTrukket(
 fun defaultSøknad(
     søknadId: UUID = UUID.randomUUID(),
     søknadsPeriode: Periode = Periode(LocalDate.now().plusDays(5), LocalDate.now().plusDays(5)),
-    søkersIdentitetsnummer: String = "01017000299",
+    søkersIdentitetsnummer: String = "23500180528",
     arbeidstid: Arbeidstid? = Arbeidstid().medArbeidstaker(listOf(defaultArbeidstid(listOf(søknadsPeriode)))),
     tilsynsordning: Tilsynsordning? = defaultTilsynsordning(
         mapOf(
@@ -124,7 +124,7 @@ fun defaultSøknad(
 
 fun defaultEttersendelse(
     søknadId: UUID = UUID.randomUUID(),
-    søkersIdentitetsnummer: String = "01017000299",
+    søkersIdentitetsnummer: String = "23500180528",
     pleietrengendeIdentitetsnummer: String = "24026223267",
     mottattDato: ZonedDateTime = ZonedDateTime.now()
 ): Ettersendelse = Ettersendelse.builder()
@@ -139,7 +139,7 @@ fun defaultEttersendelse(
 
 fun defaultPleiepengerSyktBarn(
     søknadsPeriode: Periode = Periode(LocalDate.now().plusDays(5), LocalDate.now().plusDays(5)),
-    barnNorskIdentitetsnummer: String = "01017000299",
+    barnNorskIdentitetsnummer: String = "23500180528",
     arbeidstid: Arbeidstid? = Arbeidstid().medArbeidstaker(listOf(defaultArbeidstid(listOf(søknadsPeriode)))),
     tilsynsordning: Tilsynsordning? = defaultTilsynsordning(
         mapOf(

--- a/src/test/resources/__files/barn.json
+++ b/src/test/resources/__files/barn.json
@@ -2,7 +2,7 @@
   "barn": [
     {
       "aktør_id": "22222222222",
-      "identitetsnummer": "01017000299",
+      "identitetsnummer": "23500180528",
       "fødselsdato": "2005-02-12",
       "fornavn": "Ole,",
       "mellomnavn": null,
@@ -10,7 +10,7 @@
     },
     {
       "aktør_id": "33333333333",
-      "identitetsnummer": "01017000299",
+      "identitetsnummer": "23500180528",
       "fødselsdato": "2005-10-30",
       "fornavn": "Dole,",
       "mellomnavn": null,


### PR DESCRIPTION
Erstatter gamle fiktive FNR brukt i tester med nytt fiktivt syntetiske personnummer (23500180528) som automatisk ignoreres av sif-code-scan.

Relatert til navikt/sif-gha-workflows#280