### PR TITLE
Bump spring boot

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "4.0.5"
+    id("org.springframework.boot") version "4.0.6"
     id("io.spring.dependency-management") version "1.1.7"
     id("com.expediagroup.graphql") version "9.1.0"
     kotlin("jvm") version "2.3.20"
@@ -14,8 +14,6 @@ plugins {
 group = "no.nav"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_25
-
-extra["tomcat.version"] = "11.0.21"
 
 configurations {
     compileOnly {


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det var en kritisk sårbarhet i tomcat, som følger med spring boot. For å løse den, måtte vi eksplisitt legge inn en spesifikk versjon av tomcat. Nyeste versjon av spring boot inkluderer tomcat.version = "11.0.21" så da kan vi fjerne denne spesifiseringen og bumpe spring boot.

### **Løsning**
Bump spring og fjern tomcat spesifisering. 