### PR TITLE
Fiks: Legger til falback verdi for dokument tittel

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/dokumentoversikt/DokumentService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/dokumentoversikt/DokumentService.kt
@@ -70,7 +70,7 @@ class DokumentService(
                 val dokumentvariant =
                     dokumentInfo.dokumentvarianter.first { it!!.variantformat == Variantformat.ARKIV }!!
                 val brukerHarTilgang = dokumentvariant.brukerHarTilgang
-                val tittel = dokumentInfo.tittel!!
+                val tittel = dokumentInfo.tittel ?: "Dokument uten tittel"
 
                 val dokumentType = utledDokumentType(dokumentInfo)
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi fikk en nullpointer feil for et dokument som manglet tittel. 

Slack alarm: https://nav-it.slack.com/archives/C012DDKU0EN/p1778521059658049

### **Løsning**
Legger til falback verdi 